### PR TITLE
Updating willRespondToUser code for UITextField and UITableView

### DIFF
--- a/Sources/Swift/Simulation Extensions/UITableViewSimulation.swift
+++ b/Sources/Swift/Simulation Extensions/UITableViewSimulation.swift
@@ -34,7 +34,7 @@ import UIKit
         guard !rowBounds.isEmpty else { return nil }
         let rowCenter = self.convert(rowBounds.midPoint, to: topView)
         let hitView = topView.hitTest(rowCenter, with: nil)
-        guard hitView === self || self.contains(subview: hitView) else { return nil }
+        guard hitView === self || self.contains(subview: hitView) || hitView?.contains(subview: self) ?? false else { return nil }
 
         guard let delegate = self.delegate else { return nil }
         guard delegate.responds(to: #selector(UITableViewDelegate.tableView(_:willSelectRowAt:))) else { return indexPath }

--- a/Sources/Swift/Simulation Extensions/UITextFieldSimulation.swift
+++ b/Sources/Swift/Simulation Extensions/UITextFieldSimulation.swift
@@ -8,6 +8,13 @@ import UIKit
 
 @nonobjc public extension UITextField
 {
+    /// Determine if the receiver will respond to user touches in the center of the view.
+    ///
+    @objc override var willRespondToUser: Bool {
+        let hitView = self.touchWillHitView
+        return hitView === self || self.contains(subview: hitView) || hitView?.contains(subview: self) ?? false
+    }
+    
 	/// Returns true if the receiver's clear button is currently visible; false otherwise.
 	///
     var clearButtonIsVisible: Bool {

--- a/Sources/Swift/Simulation Extensions/UITextViewSimulation.swift
+++ b/Sources/Swift/Simulation Extensions/UITextViewSimulation.swift
@@ -8,13 +8,6 @@ import UIKit
 
 @nonobjc public extension UITextView
 {
-    /// Determine if the receiver will respond to user touches in the center of the view.
-    ///
-    @objc override var willRespondToUser: Bool {
-        let hitView = self.touchWillHitView
-        return hitView === self || self.contains(subview: hitView) || hitView?.contains(subview: self) ?? false
-    }
-    
 	/// Simulate a user touch in the receiver.
 	///
     func simulateTouch() {

--- a/Sources/Swift/Simulation Extensions/UITextViewSimulation.swift
+++ b/Sources/Swift/Simulation Extensions/UITextViewSimulation.swift
@@ -8,6 +8,13 @@ import UIKit
 
 @nonobjc public extension UITextView
 {
+    /// Determine if the receiver will respond to user touches in the center of the view.
+    ///
+    @objc override var willRespondToUser: Bool {
+        let hitView = self.touchWillHitView
+        return hitView === self || self.contains(subview: hitView) || hitView?.contains(subview: self) ?? false
+    }
+    
 	/// Simulate a user touch in the receiver.
 	///
     func simulateTouch() {


### PR DESCRIPTION
I was having issues getting UIUTest to work with views I had were contained within a container view that was handling taps.  This checks not just down the view hierarchy, but also up the view hierarchy.