### PR TITLE
UIAlertAction did not dismiss UIAlertController when invoking the han…

### DIFF
--- a/Sources/Swift/Simulation Extensions/UIAlertActionSimulation.swift
+++ b/Sources/Swift/Simulation Extensions/UIAlertActionSimulation.swift
@@ -18,6 +18,13 @@ import UIKit
             let handlerPtr = UnsafeRawPointer(Unmanaged<AnyObject>.passUnretained(handlerBlock as AnyObject).toOpaque())
             let handler = unsafeBitCast(handlerPtr, to: (@convention(block) (UIAlertAction) -> Void).self)
             handler(self)
+
+            guard let alertController = self.value(forKey: "_alertController") as? UIAlertController else { return }
+
+            if !alertController.isBeingDismissed,
+               !alertController.hasBeenDismissed {
+                alertController.dismiss(animated: true)
+            }
         }
     }
 }


### PR DESCRIPTION
…dler.

When simulating touch on a UIAlertAction, the alert remained on the screen.  This change pulls the internal variable for the alert controller holding the action, and calls dismiss on that controller.  I did not see the unit tests to write a test for this change.  I confirmed it worked for me in my own project.

I added possible safety around the alertController already being in the process of dismissal, but have not done the due diligence to protect against all scenarios where we may not want to call dismiss.